### PR TITLE
Adding bundleconfig file to minify js on build

### DIFF
--- a/Codecamp/Codecamp.csproj
+++ b/Codecamp/Codecamp.csproj
@@ -23,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="BuildBundlerMinifier" Version="2.8.391" />
     <PackageReference Include="MailKit" Version="2.1.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.6.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />

--- a/Codecamp/Views/Speakers/Index.cshtml
+++ b/Codecamp/Views/Speakers/Index.cshtml
@@ -144,7 +144,7 @@ else
         }
         else
         {
-            <div>There are currentnly no speakers...</div>
+            <div>There are currently no speakers...</div>
         }
     </div>
 }

--- a/Codecamp/bundleconfig.json
+++ b/Codecamp/bundleconfig.json
@@ -1,0 +1,14 @@
+[
+    {
+        "outputFileName": "wwwroot/js/site.min.js",
+        "inputFiles": [
+            "wwwroot/js/site.js"
+        ],
+        "minify": {
+            "enabled": true,
+            "renameLocals": true
+        },
+        "sourceMap": false,
+        "includeInProject": true
+    }
+]

--- a/Codecamp/wwwroot/js/site.min.js
+++ b/Codecamp/wwwroot/js/site.min.js
@@ -1,1 +1,1 @@
-﻿
+function setSpeakerImage(n,t){let i=location.origin+"/api/speakers/"+t+"/image";fetch(i).then(function(n){if(n.ok)return n.blob()}).then(function(t){const i=URL.createObjectURL(t);n.src=i}).catch(function(n){console.log(n)})}function setSponsorImage(n){let t=location.origin+"/api/sponsors/"+id+"/image";fetch(t).then(function(n){if(n.ok)return n.blob()}).then(function(t){const i=URL.createObjectURL(t);n.src=i}).catch(function(n){console.log(n)})}


### PR DESCRIPTION
The problem with the js file was that the dev builds used site.js, and prod builds (see _Layout.cshtml)

There were a couple different ways to fix the problem, but I read that [Microsoft recommended](https://docs.microsoft.com/en-us/aspnet/core/client-side/bundling-and-minification?view=aspnetcore-2.2&tabs=visual-studio) using 3p Nuget Library called [BuildBundlerMinifier](https://www.nuget.org/packages/BuildBundlerMinifier/) for minification. This made it easy to add a configuration file that would minify site.js on build.

This was an easy fix, but if you don't like the idea of adding a 3p Nuget Package then you could always just minifiy the js another way or just link to the non-minified version for all configurations.