### PR TITLE
Updating README to add publishing verification instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the source code for Code Campster!
 
-## Requirements
+## Getting started
 
 This site requires that the computer you are working on has the .NET Core 2.1.4 SDK installed, and access to a SQL Server database for the project.
 
@@ -72,3 +72,25 @@ dotnet ef database update
 # build the project
 dotnet run
 ```
+
+### Verifying the published files
+
+There are [many different methods available for publishing](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/?view=aspnetcore-2.2), but one easy way to troubleshoot deployment problems is to test out a local deployment.
+
+.NET Core makes this really easy, just run through the following commands below to run the website from the published files. 
+
+```powershell
+# Make sure you are in the website project directory
+cd Codecamp
+
+# Publish the directory to disk:
+dotnet publish --configuration=release
+
+# cd to the output directory
+cd bin\release\netcoreapp2.1\publish\
+
+# Run the website
+dotnet .\Codecamp.dll
+```
+
+Read more about [dotnet core hosting options in the official documentation](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/?view=aspnetcore-2.1&tabs=windows).


### PR DESCRIPTION
I took a quick crash course on how to run the published version of the site when I was looking at the site.js issue. I figured I might as well write it down in case somebody else needs to do it.