### PR TITLE
Adding Read-Only Resource Group Lock on Deployments

### DIFF
--- a/iac/armdeploy.json
+++ b/iac/armdeploy.json
@@ -50,6 +50,18 @@
     },
     "resources": [
         {
+            "type": "Microsoft.Web/sites/providers/locks",
+            "apiVersion": "2016-09-01",
+            "name": "[concat(parameters('name'), '/Microsoft.Authorization/siteLock')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('name'))]"
+            ],
+            "properties": {
+                "level": "ReadOnly",
+                "notes": "Site is readonly"
+            }
+        },
+        {
             "apiVersion": "2018-11-01",
             "name": "[parameters('name')]",
             "type": "Microsoft.Web/sites",

--- a/iac/armdeploy.json
+++ b/iac/armdeploy.json
@@ -50,7 +50,7 @@
     },
     "resources": [
         {
-            "type": "Microsoft.Authorization/locks	",
+            "type": "Microsoft.Authorization/locks",
             "apiVersion": "2016-09-01",
             "name": "readonly",
             "dependsOn": [

--- a/iac/armdeploy.json
+++ b/iac/armdeploy.json
@@ -50,15 +50,16 @@
     },
     "resources": [
         {
-            "type": "Microsoft.Web/sites/providers/locks",
+            "type": "Microsoft.Authorization/locks	",
             "apiVersion": "2016-09-01",
-            "name": "[concat(parameters('name'), '/Microsoft.Authorization/siteLock')]",
+            "name": "readonly",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/sites', parameters('name'))]"
+                "[resourceId('Microsoft.Web/sites', parameters('name'))]",
+                "[concat('Microsoft.Web/serverfarms/', parameters('hostingPlanName'))]"
             ],
             "properties": {
                 "level": "ReadOnly",
-                "notes": "Site is readonly"
+                "notes": "Resource group is readonly"
             }
         },
         {

--- a/pipelines/main.yml
+++ b/pipelines/main.yml
@@ -80,7 +80,7 @@ stages:
         displayName: "Delete resource group lock"
         inputs:
           azureSubscription: '$(Azure.ServiceConnection)'
-          scriptType: 'batch'
+          scriptType: bash
           scriptLocation: 'inlineScript'
           inlineScript: 'az group lock delete -g $(ResourceGroup) -n readonly'
       - task: AzureResourceManagerTemplateDeployment@3


### PR DESCRIPTION
We won't be able to make changes to production without going through the pipeline or by explicitly removing the lock